### PR TITLE
[FOR-4925] New annotation, only log response and not request

### DIFF
--- a/servicebuilder-core-addons/src/main/java/no/obos/util/servicebuilder/log/ServerLogFilter.java
+++ b/servicebuilder-core-addons/src/main/java/no/obos/util/servicebuilder/log/ServerLogFilter.java
@@ -79,7 +79,7 @@ public class ServerLogFilter implements ContainerRequestFilter, ContainerRespons
 
         LogParams logParams = serverLogger.LogParamsForCall(handlingClass, handlingMethod);
 
-        if (! logParams.enableLogging) {
+        if (! logParams.enableLogging || logParams.logOnlyResponse) {
             return;
         }
 
@@ -112,8 +112,6 @@ public class ServerLogFilter implements ContainerRequestFilter, ContainerRespons
             Map<String, String> headers = FormatUtil.MultiMapAsStringMap(request.getHeaders());
             logRequest.headers((ImmutableMap.copyOf(headers)));
         }
-
-
 
         if (logParams.logRequestPayload) {
             logRequest.entity(extractRequestEntity(request));

--- a/servicebuilder-core-addons/src/main/java/no/obos/util/servicebuilder/log/ServerLogger.java
+++ b/servicebuilder-core-addons/src/main/java/no/obos/util/servicebuilder/log/ServerLogger.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.obos.util.servicebuilder.annotations.Log;
+import no.obos.util.servicebuilder.annotations.LogOnlyResponse;
 import no.obos.util.servicebuilder.annotations.LogRequestEntity;
 import no.obos.util.servicebuilder.annotations.LogResponseEntity;
 import no.obos.util.servicebuilder.log.model.LogParams;
@@ -44,6 +45,11 @@ public class ServerLogger {
             ret = ret.enableLogging(enableLogging.value());
         }
 
+        LogOnlyResponse logOnlyResponse = AnnotationUtil.getAnnotation(LogOnlyResponse.class, method);
+        if (logOnlyResponse != null) {
+            ret = ret.logOnlyResponse(logOnlyResponse.value());
+        }
+
         LogRequestEntity logRequestEntity = AnnotationUtil.getAnnotation(LogRequestEntity.class, method);
         if (logRequestEntity != null) {
             ret = ret.logRequestPayload(logRequestEntity.value());
@@ -54,7 +60,6 @@ public class ServerLogger {
             ret = ret.logResponseEntity(logResponseEntity.value());
         }
         return ret;
-
     }
 
     public void handleRequest(LogRequest logRequest, LogParams logParams) {

--- a/servicebuilder-core-addons/src/main/java/no/obos/util/servicebuilder/log/model/LogParams.java
+++ b/servicebuilder-core-addons/src/main/java/no/obos/util/servicebuilder/log/model/LogParams.java
@@ -50,7 +50,14 @@ public class LogParams {
     @Wither(AccessLevel.PRIVATE)
     public final boolean logRequestPayload;
 
-    public final static LogParams defaults = new LogParams(true, LogLevel.INFO, false, ImmutableSet.of(), true, true);
+    /**
+     * default er false, og om det er false logges request og response.
+     * Om det er true, logges kun response
+     */
+    @Wither(AccessLevel.PRIVATE)
+    public final boolean logOnlyResponse;
+
+    public static final LogParams defaults = new LogParams(true, LogLevel.INFO, false, ImmutableSet.of(), true, true, false);
 
     public LogParams enableLogging(boolean enableLogging) {
         return withEnableLogging(enableLogging);
@@ -65,7 +72,7 @@ public class LogParams {
     }
 
     public LogParams skipHeaders(ImmutableSet<String> skipHeaders) {
-        return this.skipHeaders == skipHeaders ? this : new LogParams(this.enableLogging, this.logLevel, this.logHeaders, skipHeaders, this.logResponseEntity, this.logRequestPayload);
+        return this.skipHeaders == skipHeaders ? this : new LogParams(this.enableLogging, this.logLevel, this.logHeaders, skipHeaders, this.logResponseEntity, this.logRequestPayload, this.logOnlyResponse);
     }
 
     public LogParams clearSkipHeaders() {
@@ -83,4 +90,9 @@ public class LogParams {
     public LogParams logRequestPayload(boolean logRequestPayload) {
         return withLogRequestPayload(logRequestPayload);
     }
+
+    public LogParams logOnlyResponse(boolean logOnlyResponse) {
+        return withLogOnlyResponse(logOnlyResponse);
+    }
+
 }

--- a/servicebuilder-interfaces/src/main/java/no/obos/util/servicebuilder/annotations/LogOnlyResponse.java
+++ b/servicebuilder-interfaces/src/main/java/no/obos/util/servicebuilder/annotations/LogOnlyResponse.java
@@ -1,0 +1,12 @@
+package no.obos.util.servicebuilder.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LogOnlyResponse {
+    boolean value() default false;
+}


### PR DESCRIPTION
To cut down on number of logs, only the response should be logged and not the request.
Normally for every request there will be two logs, one for request that will inform about the method, context-path and potential request-body, and one identical but with response, millis and entity. We only need the latter log if it's a GET request.

# Task
https://obos-bbl.atlassian.net/browse/FOR-4925

# Changes
* Add new annotation `@LogOnlyResponse`
    * Default is set to false
    * Will only log the response and not the request when set to true
 
## Example
To use it you have to set `LogOnlyResponse` to `true` like this `@LogOnlyResponse(true)` or like this `@LogOnlyResponse(value = true)`
### Without the annotation
`2024-08-14 09:41:43,628 INFO [0fe1aef1-81b8-1337-hello-0021a8dff2fd] n.o.u.s.client.ClientLogFilter GET http://app.obos.no/bolig/v4/api/selskap/1445/organisasjonsnumre`
`2024-08-14 09:41:43,646 INFO [0fe1aef1-81b8-1337-hello-0021a8dff2fd] n.o.u.s.client.ClientLogFilter GET http://app.obos.no/bolig/v4/api/selskap/1445/organisasjonsnumre response: 200, millis: 18`

### With the annotation 
`2024-08-14 09:41:43,646 INFO [0fe1aef1-81b8-1337-hello-0021a8dff2fd] n.o.u.s.client.ClientLogFilter GET http://app.obos.no/bolig/v4/api/selskap/1445/organisasjonsnumre response: 200, millis: 18`




